### PR TITLE
fix screen rotation

### DIFF
--- a/ssd1306/ssd1306.c
+++ b/ssd1306/ssd1306.c
@@ -405,8 +405,6 @@ int ssd1306_draw_pixel(const ssd1306_t *dev, uint8_t *fb, int8_t x, int8_t y, ss
 
     if ((x >= dev->width) || (x < 0) || (y >= dev->height) || (y < 0))
         return -EINVAL;
-    y = dev->height - y - 1;
-    x = dev->width - x - 1;
     index = x + (y / 8) * dev->width;
     switch (color) {
         case OLED_COLOR_WHITE:


### PR DESCRIPTION
Hi Fonger!

First of all I want to thank you for this port. I was able to quickly start my hobby project with a 128x64 SSD1306 display using this code with the ESP8266_RTOS_SDK v3.3.

I drew some text and it looked good but when I used _ssd1306_draw_hline_ it didn't look like these two draw calls use the same coordinate system. I looked into it and that's when I noticed these two lines of code in _ssd1306_draw_pixel_  (which are unique to this port, they are not in _esp-open-rtos/extras_). As I removed them, the draw calls were drawing in the same coordinate system but now things were turned around 180 degrees. The correct way to turn them around is:

`ssd1306_set_segment_remapping_enabled(&dev, true);`
`ssd1306_set_scan_direction_fwd(&dev, false);`
